### PR TITLE
🐛 Delay calculation was incorrectly converting using the system timezone

### DIFF
--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -8,13 +8,15 @@ namespace Demo
         {
             var expression = "0-30/5 * * * * *";
             Console.WriteLine(expression);
-            var timer = new CronTimer(expression, "Europe/Amsterdam", includingSeconds: true);
+            var timer = new CronTimer(expression, "Asia/Hong_Kong", includingSeconds: true);
             timer.OnOccurence += (s, ea) => Console.WriteLine($"{ea.At:T} - {DateTime.Now}");
             timer.Start();
 
             while (Console.ReadKey().Key != ConsoleKey.Escape)
             {
             }
+
+            timer.Stop();
         }
     }
 }

--- a/src/CronTimer.cs
+++ b/src/CronTimer.cs
@@ -59,7 +59,8 @@ public class CronTimer
         TimeSpan delay;
         if (tz != UTC)
         {
-            delay = Next.ToUniversalTime() - nowUtc;
+            var nextUtc = TimeZoneInfo.ConvertTimeToUtc(Next, tzi);
+            delay = nextUtc - nowUtc;
         }
         else
         {


### PR DESCRIPTION
Delay calculation was incorrectly converting using the system timezone. Now using the configured timezone.

- Resolves https://github.com/ramonsmits/CronTimer/issues/3