### PR TITLE
Backport of #4

### DIFF
--- a/src/CronTimer.cs
+++ b/src/CronTimer.cs
@@ -59,7 +59,8 @@ public class CronTimer
         TimeSpan delay;
         if (tz != UTC)
         {
-            delay = Next.ToUniversalTime() - nowUtc;
+            var nextUtc = TimeZoneInfo.ConvertTimeToUtc(Next, tzi);
+            delay = nextUtc - nowUtc;
         }
         else
         {


### PR DESCRIPTION
🐛 Delay calculation was incorrectly converting using the system timezone. Now using the configured timezone.